### PR TITLE
Timeline chart should stay in box boundaries

### DIFF
--- a/frontend_personicle/reactComponents/TimelineChart.js
+++ b/frontend_personicle/reactComponents/TimelineChart.js
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Spinner } from "react-bootstrap";
 import sample_events from "../sample_data/sample_events"
-import MyComponent from '../reactComponents/MyComponent'
 
 function TimelineChart ({google}) {
   console.log("Create TimelineChart");
@@ -13,15 +12,6 @@ function TimelineChart ({google}) {
   })
 
   useEffect(() => {
-    // function handleResize() {
-    //   console.log(window.innerWidth);
-    //   setChart({
-    //     height: window.innerHeight,
-    //     width: window.innerWidth
-    //   })
-    // }
-
-    //window.addEventListener('resize', handleResize)
 
     if (google && !chart) {
 
@@ -83,11 +73,8 @@ function TimelineChart ({google}) {
 
       // Create a timeline chart, passing some options
       var timelineOptions = {
-        title: 'DAILY GRAPH',
         width: window.innerWidth,
-        height: 500,
-        hAxis: { title: 'NOVEMBER', titleTextStyle: { color: '#333' } },
-        vAxis: { minValue: 0 }
+        height: 500, //window.innerHeight,        
     };
 ;
       var timelineChart = new google.visualization.ChartWrapper({
@@ -109,9 +96,8 @@ function TimelineChart ({google}) {
         const chart = new google.visualization.Timeline(document.getElementById('timeline'));
 
         timelineOptions.width = .4 * window.innerWidth;
-        //timelineOptions.height = .4 * window.innerHeight;
+        timelineOptions.height = .4 * window.innerHeight;
   
-        //chart.draw(data, timelineOptions);
         dashboard.draw(data, options);
       }
 
@@ -129,21 +115,6 @@ function TimelineChart ({google}) {
 
   return (
     <>
-    {/* <style>
-    #dashboard_div{
-      position: relative;
-      padding-bottom: 100%;
-      height: 0;
-      overflow: hidden;
-    }
-    #timeline {
-      position: absolute;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 500px;
-    }
-  </style> */}
     <div>
       <h1>Gantt Chart</h1>
       <p> This is a simple Next.js page showing a Gantt Chart with activities imported from exercise.json in the PMData Set. Activities are on the y-axis, and dates with start and end time on the x-axis.  </p>

--- a/frontend_personicle/reactComponents/TimelineChart.js
+++ b/frontend_personicle/reactComponents/TimelineChart.js
@@ -1,11 +1,28 @@
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Spinner } from "react-bootstrap";
 import sample_events from "../sample_data/sample_events"
+import MyComponent from '../reactComponents/MyComponent'
 
 function TimelineChart ({google}) {
+  console.log("Create TimelineChart");
+
   const [chart, setChart] = useState(null);
+  const [dimensions, setDimensions] = useState({ 
+    height: 0,
+    width: 0
+  })
 
   useEffect(() => {
+    // function handleResize() {
+    //   console.log(window.innerWidth);
+    //   setChart({
+    //     height: window.innerHeight,
+    //     width: window.innerWidth
+    //   })
+    // }
+
+    //window.addEventListener('resize', handleResize)
+
     if (google && !chart) {
 
       // Create functions 
@@ -34,6 +51,7 @@ function TimelineChart ({google}) {
       // Create the data table.
       
       const data = new google.visualization.DataTable();
+  
       data.addColumn({ type: 'string', id: 'Events' });
       data.addColumn({ type: 'string', id: 'Task ID' });
       data.addColumn({ type: 'date', id: 'Start Date' });
@@ -45,8 +63,8 @@ function TimelineChart ({google}) {
   
       // Set chart options
       var options = {'title':'Gantt Chart Timeline Visualization',
-                    'width':500,
-                    'height':300,
+                    'width':' 100%',
+                    'height': '100%',
                     timeline: { groupByRowLabel: true}, 
                     displayAnnotations: true};
 
@@ -64,34 +82,68 @@ function TimelineChart ({google}) {
       });
 
       // Create a timeline chart, passing some options
+      var timelineOptions = {
+        title: 'DAILY GRAPH',
+        width: window.innerWidth,
+        height: 500,
+        hAxis: { title: 'NOVEMBER', titleTextStyle: { color: '#333' } },
+        vAxis: { minValue: 0 }
+    };
+;
       var timelineChart = new google.visualization.ChartWrapper({
         'chartType': 'Timeline',
         'containerId': 'timeline',
-        'options': {
-          'width': 1000,
-          'height': 500,
-          'pieSliceText': 'value',
-          'legend': 'right'
-        }
+        'options': timelineOptions
       });
 
-      // Instantiate and draw our chart, passing in some options.
-      //var container = document.getElementById('timeline');
-      //var chart = new google.visualization.Timeline(container);
-
+      // Instantiate and draw our dashboard and chart, passing in some options.
       var dashboard = new google.visualization.Dashboard(
         document.getElementById('dashboard_div'));
      
-      const chart = new google.visualization.Timeline(document.getElementById('timeline'));
-      dashboard.bind(dateRangeSlider, timelineChart);
-      dashboard.draw(data, options);
-      setChart(timeline);
-      
+        dashboard.bind(dateRangeSlider, timelineChart);
+        dashboard.draw(data, options);
+        
+      function resize () {
+        console.log("called resize");
+
+        const chart = new google.visualization.Timeline(document.getElementById('timeline'));
+
+        timelineOptions.width = .4 * window.innerWidth;
+        //timelineOptions.height = .4 * window.innerHeight;
+  
+        //chart.draw(data, timelineOptions);
+        dashboard.draw(data, options);
+      }
+
+      window.onload = resize;
+      window.onresize = resize;
     }
+    
+    //Re-Render Chart on Window Resize
+    // return _ => {
+    //   window.removeEventListener('resize', handleResize)}  
+
   }, [google, chart]);
+
+
 
   return (
     <>
+    {/* <style>
+    #dashboard_div{
+      position: relative;
+      padding-bottom: 100%;
+      height: 0;
+      overflow: hidden;
+    }
+    #timeline {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 500px;
+    }
+  </style> */}
     <div>
       <h1>Gantt Chart</h1>
       <p> This is a simple Next.js page showing a Gantt Chart with activities imported from exercise.json in the PMData Set. Activities are on the y-axis, and dates with start and end time on the x-axis.  </p>
@@ -99,7 +151,7 @@ function TimelineChart ({google}) {
       {!google && <Spinner />}
       <div id="dashboard_div">
         <div id="filter_div"></div>
-        <div id="timeline" className={!google ? 'd-none' : ''} />
+        <div id="timeline" className={!google ? 'd-none' : ''}/>
       </div>
       
     </>


### PR DESCRIPTION
Card Link: https://github.com/vin-clearsense/frontend-personicle/issues/16#issue-1146275771

- When window is resized, timeline chart is responsive
- Submitted to Vaibhav for testing to ensure that it stays within box boundaries, which are not visible from my end
- Once Vaibhav approves that the code is functional on his end, I will resubmit with unnecessary comments removed of other ways of implementing the functionality. 